### PR TITLE
removed old solc versions, use 0.8.x only instead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,15 +203,9 @@ jobs:
           - ubuntu-latest
           - windows-latest
         solc:
-          - "0.4.25"
-          - "0.5.7"
-          - "0.6.12"
-          - "0.7.5"
+          - "0.8.10"
+          - "0.8.25"
         include:
-          - solc: "0.6.12"
-            experimental: true
-          - solc: "0.7.5"
-            experimental: true
           - os: windows-latest
             experimental: true
 

--- a/src/test/Tests/Integration.hs
+++ b/src/test/Tests/Integration.hs
@@ -60,8 +60,6 @@ integrationTests = testGroup "Solidity Integration Testing"
       [ ("echidna_library_call failed",            solved      "echidna_library_call")
       , ("echidna_valid_timestamp failed",         passed      "echidna_valid_timestamp")
       ]
-  , testContractV "basic/fallback.sol"   (Just (< solcV (0,6,0))) Nothing
-      [ ("echidna_fallback failed",                solved      "echidna_fallback") ]
   , testContract "basic/push_long.sol" (Just "basic/push_long.yaml")
       [ ("test_long_5 passed",                     solvedWithout NoCall "test_long_5")]
   , testContract "basic/propGasLimit.sol" (Just "basic/propGasLimit.yaml")
@@ -83,17 +81,8 @@ integrationTests = testGroup "Solidity Integration Testing"
       [ ("echidna_mutated passed",                 solved      "echidna_mutated") ]
   , testContract "basic/darray-mutation.sol"  Nothing
       [ ("echidna_mutated passed",                 solved      "echidna_mutated") ]
-  , testContract "basic/gasuse.sol"       (Just "basic/gasuse.yaml")
-      [ ("echidna_true failed",                    passed     "echidna_true")
-      , ("g gas estimate wrong",                   gasInRange "g" 130000 40000000)
-      , ("f_close1 gas estimate wrong",            gasInRange "f_close1" 400 2000)
-      , ("f_open1 gas estimate wrong",             gasInRange "f_open1"  18000 23000)
-      , ("push_b gas estimate wrong",              gasInRange "push_b"   39000 45000)
-      ]
   , testContract "basic/gaslimit.sol"  Nothing
       [ ("echidna_gaslimit passed",                passed      "echidna_gaslimit") ]
-  ,  testContractV "basic/killed.sol"      (Just (< solcV (0,8,0))) (Just "basic/killed.yaml")
-      [ ("echidna_still_alive failed",             solved      "echidna_still_alive") ]
   ,  checkConstructorConditions "basic/codesize.sol"
       "invalid codesize"
   , testContractV "basic/eip-170.sol" (Just (>= solcV (0,5,0))) (Just "basic/eip-170.yaml")

--- a/src/test/Tests/Integration.hs
+++ b/src/test/Tests/Integration.hs
@@ -2,7 +2,7 @@ module Tests.Integration (integrationTests) where
 
 import Test.Tasty (TestTree, testGroup)
 
-import Common (testContract, testContractV, solcV, testContract', checkConstructorConditions, passed, solved, solvedLen, solvedWith, solvedWithout, gasInRange)
+import Common (testContract, testContractV, solcV, testContract', checkConstructorConditions, passed, solved, solvedLen, solvedWith, solvedWithout)
 import Data.Functor ((<&>))
 import Data.Text (unpack)
 import Echidna.Types.Campaign (WorkerType(..))

--- a/src/test/Tests/Research.hs
+++ b/src/test/Tests/Research.hs
@@ -10,7 +10,7 @@ researchTests :: TestTree
 researchTests = testGroup "Research-based Integration Testing"
   [ testContract "research/harvey_foo.sol" Nothing
       [ ("echidna_assert failed",     solved "echidna_assert") ]
-  , testContract' "research/harvey_baz.sol" Nothing Nothing Nothing False FuzzWorker
+  , testContract "research/harvey_baz.sol" Nothing
       [ ("echidna_all_states failed", solved "echidna_all_states") ]
   , testContract' "research/ilf_crowdsale.sol" Nothing (Just (\v -> v >= solcV (0,5,0) && v < solcV (0,6,0))) (Just "research/ilf_crowdsale.yaml") False FuzzWorker
       [ ("echidna_assert failed", solved "withdraw") ]


### PR DESCRIPTION
Removed old solc versions tests, keeping only 0.8.x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the testing pipeline by replacing older Solidity compiler versions with newer releases.
	- Removed experimental configurations for legacy compiler versions, streamlining the overall testing setup.
	- Simplified and removed certain Solidity integration tests to reflect updated test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->